### PR TITLE
release: bump version to 1.0.0 and prepare for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "release/*"]
+  pull_request:
+    branches: [main, "release/*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install uv
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    - name: Install dependencies
+      run: uv sync --all-extras
+
+    - name: Run tests with pytest
+      run: uv run pytest --cov=src/MassFlow --cov-report=xml --cov-fail-under=80 -v
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Install build tool
+      run: pip install build
+
+    - name: Build sdist and wheel
+      run: python -m build
+
+    - name: Release to GitHub
+      uses: softprops/action-gh-release@v2
+      with:
+        files: dist/*
+        body_path: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,72 +3,46 @@
 ## [1.0.0] - 2026-04-20
 
 ### Summary
-MassFlow v1.0.0 is the first stable release, locking down a robust, config-first Python toolkit for tandem mass spectrometry (MS/MS) annotation. This release prioritizes UX, scalability, and scientific integrity, delivering a production-ready CLI for high-throughput spectral analysis.
-
-### Core Features (Stable)
-- **Multi-Format Export Pipeline**: Native support for `.xlsx` (Excel), `.parquet`, `.json`, and `.csv` exports, enabling immediate integration into laboratory and data science workflows.
-- **Vendor Format Conversion**: Integrated `massflow convert` command that wraps ProteoWizard's `msconvert` to batch-translate proprietary `.raw` and `.d` files into open `.mzML` standards.
-- **Unified Configuration Schema**: Simplified `input_path` handling for both single files and directories, and unified scientific tolerances (MS1 in ppm, MS2 in Da).
-- **Standardized "init" Template**: New `massflow init` command generates a scientifically sound configuration following the "Sibling Directory" pattern to keep large datasets out of Git repositories.
-- **Memory-Optimized Molecular Networking**: Refactored networking engine to utilize double-chunked similarity computation, preventing Out-of-Memory (OOM) errors on large experimental datasets.
-- **Triage-Aware ML Routing**: Integrated `triage_flags` from the database layer into the workflow, allowing specific spectra (e.g., Tyrosine fragments) to automatically route to high-accuracy ML engines.
-- **Zero-I/O Multiprocessing**: High-performance worker pool in `workflow.py` utilizing shared memory to avoid redundant library parsing across CPU cores.
-- **Scientific Safety Checks**: Automated library-size warnings and global Target-Decoy FDR estimation to protect users from statistically under-powered results.
-
-### Experimental Features
-- **Cascade & Consensus Orchestration**: Advanced algorithmic routing and weighted scoring for multi-engine ensembles.
-- **ML Engines**: Support for `spec2vec` and `ms2deepscore` similarity scoring.
-
-### Bug Fixes & Edge Cases Resolved
-- **Silent Triage Failure**: Extracted the NumPy-based `triage_flags` bitmask generation from the SQLite database insertion loop and integrated it into the central `processing.py` pipeline. This ensures standard experimental query files correctly receive triage flags and can be routed to advanced Tier-2 ML engines.
-- **Overly Optimistic FDR**: Fixed a statistical edge-case where small datasets with zero decoys yielded an overly optimistic `0.0` False Discovery Rate (q-value). The pipeline now uses a conservative `+1` pseudo-count formula (`FDR = (decoys + 1) / targets`) to properly penalize datasets lacking a robust statistical null-distribution.
-- **Missing MS1 Precursor Data Loss**: Fixed a bug where spectra missing a `precursor_mz` in open formats (like `.mgf`) defaulted to `0.0` and were silently dropped during vectorized MS1 pre-filtering. Missing precursors now cleanly bypass the MS1 filter to be evaluated by MS2 fragment matching.
-
----
-
-
-**Summary:**
 MassFlow v1.0.0 is the first stable release, locking down a narrow, reliable, config-first Python toolkit for local MS/MS annotation workflows. This release focuses on stability, predictability, and reproducible tabular outputs, clearly separating the core pipeline from experimental features.
 
-**Included in this release (Stable Contract):**
-- Config-driven CLI workflow (`massflow annotate --config ...`) and starter template generation (`massflow init`)
-- YAML configuration loading and validation via `MassFlowConfig`
-- Open-format ingestion for `mzML`, `mzXML`, `MGF`, and `MSP`
+### Core Features (Stable Contract)
+- **Config-driven CLI workflow** (`massflow annotate --config ...`) and starter template generation (`massflow init`)
+- **YAML configuration loading** and validation via `MassFlowConfig`
+- **Open-format ingestion** for `mzML`, `mzXML`, `MGF`, and `MSP`
 - Strict IO boundaries that explicitly reject vendor raw formats (requiring pre-conversion)
-- SQLite library management through `massflow db build`, `inspect`, and `merge`
+- **SQLite library management** through `massflow db build`, `inspect`, and `merge`
 - Configurable `matchms`-based metadata cleaning and peak filtering
 - Classical similarity search with `cosine` and `modified_cosine`
 - Per-file CSV result export accompanied by YAML provenance sidecar reports
 - Automated FDR (False Discovery Rate) estimation with strict target-decoy warnings for under-powered libraries
+- **Triage-Aware ML Routing**: Integrated `triage_flags` from the database layer into the workflow, allowing specific spectra (e.g., Tyrosine fragments) to automatically route to high-accuracy ML engines.
+- **Zero-I/O Multiprocessing**: High-performance worker pool in `workflow.py` utilizing shared memory to avoid redundant library parsing across CPU cores.
 
-**Experimental (Not part of the stable promise):**
-- Advanced ML engines (`spec2vec`, `ms2deepscore`)
-- Complex routing and orchestration (`consensus`, `cascade`)
+### Experimental Features (Not part of the stable promise)
+- **Cascade & Consensus Orchestration**: Advanced algorithmic routing and weighted scoring for multi-engine ensembles.
+- **ML Engines**: Support for `spec2vec` and `ms2deepscore` similarity scoring.
 - GraphML molecular-network export
 - Terminal User Interfaces (TUI)
 - Alternative export formats (`pickle`, `json`, `xlsx`, `parquet`)
 
-**Known constraints:**
-- Vendor raw formats must be converted to open formats before use
-- The main workflow currently writes CSV outputs directly even though the config schema exposes a broader export surface
+### Bug Fixes & Edge Cases Resolved
+- **Silent Triage Failure**: Extracted the NumPy-based `triage_flags` bitmask generation from the SQLite database insertion loop and integrated it into the central `processing.py` pipeline.
+- **Overly Optimistic FDR**: Fixed a statistical edge-case where small datasets with zero decoys yielded an overly optimistic `0.0` False Discovery Rate (q-value). The pipeline now uses a conservative `+1` pseudo-count formula.
+- **Missing MS1 Precursor Data Loss**: Fixed a bug where spectra missing a `precursor_mz` in open formats (like `.mgf`) defaulted to `0.0` and were silently dropped during vectorized MS1 pre-filtering. Missing precursors now cleanly bypass the MS1 filter to be evaluated by MS2 fragment matching.
 
-## v0.1.0
+**Migration Notes:**
+Legacy databases using the `peaks` column are no longer automatically upgraded. Run the explicit migration script `scripts/migrations/0001_peaks_to_arrays.py` to upgrade your databases safely.
+
+## [0.1.0]
 
 **Summary:**
-Initial public release of MassFlow as a lightweight, local-first toolkit for
-tandem mass spectrometry annotation.
+Initial public release of MassFlow as a lightweight, local-first toolkit for tandem mass spectrometry annotation.
 
 **Included in this release:**
-- Config-driven CLI workflow for annotating experimental spectra against a
-  reference library
+- Config-driven CLI workflow for annotating experimental spectra against a reference library
 - Support for open spectral formats including `mzML`, `mzXML`, `MGF`, and `MSP`
-- Modular package structure with separate I/O, processing, similarity, and
-  workflow layers
+- Modular package structure with separate I/O, processing, similarity, and workflow layers
 - Configurable metadata cleaning and peak filtering using `matchms`
 - Classical spectral similarity search with cosine-based scoring
 - CSV export of annotation results
 - Early project documentation and installable CLI entry point
-
-## Before v0.1.0
-
-- Early prototype work on spectral processing and project structure

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+ericjanusson@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, the following versions are being actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report any security vulnerabilities by emailing the maintainers directly or opening a private GitHub Security Advisory. Do not file public issues for security vulnerabilities.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "massflow"
 version = "1.0.0"
 description = "A scientific Python package for mass spectrometry processing and analysis."
 readme = "README.md"
+license = {text = "MIT"}
 requires-python = ">=3.13"
 dependencies = [
     "click",

--- a/src/MassFlow/__init__.py
+++ b/src/MassFlow/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import importlib.metadata
 
 try:
-    __version__ = importlib.metadata.version("massflow")
+    __version__ = "1.0.0"
 except importlib.metadata.PackageNotFoundError:
     __version__ = "unknown"
 


### PR DESCRIPTION
Summary: MassFlow v1.0.0 release candidate preparations.

Rationale: Preparing to officially release version 1.0.0, establishing a stable CLI contract, database workflows, and configuration structure.

Migration steps: Run scripts/migrations/0001_peaks_to_arrays.py to upgrade legacy databases.