### PR TITLE
fix: manually convert numpy booleans before Polars DataFrame creation

### DIFF
--- a/src/MassFlow/io.py
+++ b/src/MassFlow/io.py
@@ -287,7 +287,15 @@ def _build_results_dataframe(
     else:
         if not results:
             return None
-        df = pl.DataFrame(results)
+
+        clean_results = []
+        for r in results:
+            clean_r = r.copy()
+            if "is_decoy" in clean_r and hasattr(clean_r["is_decoy"], "item"):
+                clean_r["is_decoy"] = clean_r["is_decoy"].item()
+            clean_results.append(clean_r)
+
+        df = pl.DataFrame(clean_results)
 
     # Add Annotation_Status
     if "score" in df.columns:


### PR DESCRIPTION
Resolves a serialization warning from Polars by manually converting numpy boolean types to standard python booleans before they are passed to `pl.DataFrame()`.

---
*PR created automatically by Jules for task [9691500476275254498](https://jules.google.com/task/9691500476275254498) started by @janusson*