### PR TITLE
Fix ionmode standardization in metadata processing

### DIFF
--- a/src/MassFlow/processing.py
+++ b/src/MassFlow/processing.py
@@ -76,8 +76,11 @@ def metadata_processing(
 
     # Pre-emptively fix ionmode to prevent matchms default_filters from raising AssertionError
     ionmode = s.get("ionmode")
-    if isinstance(ionmode, str):
-        s.set("ionmode", ionmode.lower())
+    if ionmode is not None:
+        if isinstance(ionmode, (list, tuple)):
+            ionmode = ionmode[0] if len(ionmode) > 0 else None
+        if ionmode is not None:
+            s.set("ionmode", str(ionmode).lower())
 
     # Apply default filters (handles common metadata issues)
     if config is None or getattr(config, "clean_metadata", True):


### PR DESCRIPTION
Fixes an issue where `matchms.filtering.default_filters` could raise an `AssertionError` due to `ionmode` being passed as a list or non-string type. The fix extracts the first element if it's an iterable and explicitly casts it to a string before calling `.lower()`. Empty lists/tuples are safely handled and ignored.

---
*PR created automatically by Jules for task [10421819212661290231](https://jules.google.com/task/10421819212661290231) started by @janusson*