### PR TITLE
Add Chromatographic Retention Time Filtering

### DIFF
--- a/src/MassFlow/config.py
+++ b/src/MassFlow/config.py
@@ -280,6 +280,10 @@ class SimilarityConfig(BaseModel):
         default=0.02, description="Fragment mass tolerance in Da"
     )
 
+    rt_tolerance: Optional[float] = Field(
+        default=None, description="Retention time tolerance in minutes for isomer distinction. If set, reference matches outside query_rt ± rt_tolerance are rejected."
+    )
+
     min_score: float = 0.6
     analog_search: bool = False
     min_matched_peaks: int = 3

--- a/src/MassFlow/similarity.py
+++ b/src/MassFlow/similarity.py
@@ -578,6 +578,7 @@ class SimilarityEngine:
             q_mz = q.get("precursor_mz")
             q_mz_val = float(q_mz) if q_mz is not None else None
             q_adduct: str | None = q.get("adduct")  # type: ignore[assignment]
+            q_rt_val = q.get("retention_time")
 
             for idx in final_indices:
                 ref = all_references[idx]
@@ -586,6 +587,14 @@ class SimilarityEngine:
                 ref_adduct: str | None = ref.get("adduct")  # type: ignore[assignment]
                 if not _adduct_modes_compatible(ref_adduct, q_adduct):
                     continue
+
+                # --- Retention Time Filtering ---
+                if getattr(self.config, "rt_tolerance", None) is not None:
+                    ref_rt_val = ref.get("retention_time")
+                    if not _is_missing(q_rt_val) and not _is_missing(ref_rt_val):
+                        if abs(float(q_rt_val) - float(ref_rt_val)) > self.config.rt_tolerance:
+                            continue
+
                 score_val = float(numeric_scores[idx, i])
                 match_val = int(matches_count[idx, i])
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -290,3 +290,70 @@ def test_calculate_fdr_empty_arrays():
     # With monotonicity enforced by minimum.accumulate, q-values for both are 0.5
     np.testing.assert_allclose(q, np.array([0.5, 0.5]))
     assert np.all(t)
+
+
+def test_rt_tolerance_filtering() -> None:
+    """Verify that matches outside the retention time tolerance are rejected."""
+    query = Spectrum(
+        mz=np.array([100.0, 200.0, 300.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 1.0], dtype="float"),
+        metadata={"id": "query1", "precursor_mz": 400.0, "retention_time": 600.0},
+    )
+
+    # Reference within RT tolerance
+    ref_match = Spectrum(
+        mz=np.array([100.0, 200.0, 300.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 1.0], dtype="float"),
+        metadata={"id": "ref1", "precursor_mz": 400.0, "retention_time": 600.5},
+    )
+
+    # Reference outside RT tolerance
+    ref_nomatch = Spectrum(
+        mz=np.array([100.0, 200.0, 300.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 1.0], dtype="float"),
+        metadata={"id": "ref2", "precursor_mz": 400.0, "retention_time": 602.0},
+    )
+
+    # Reference with missing RT
+    ref_missing = Spectrum(
+        mz=np.array([100.0, 200.0, 300.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 1.0], dtype="float"),
+        metadata={"id": "ref3", "precursor_mz": 400.0},
+    )
+
+    config = SimilarityConfig(
+        algorithm="cosine",
+        ms1_tolerance=10.0,
+        ms2_tolerance=10.0,
+        rt_tolerance=1.0,
+        min_score=0.0,
+        min_matched_peaks=0,
+    )
+    engine = SimilarityEngine(config)
+
+    results = engine.search(
+        query_spectra=[query],
+        reference_spectra=[ref_match, ref_nomatch, ref_missing],
+        include_decoys=False,
+    )
+
+    matched_ids = {r["reference_id"] for r in results}
+
+    assert "ref1" in matched_ids, "Reference within RT tolerance was rejected."
+    assert "ref2" not in matched_ids, "Reference outside RT tolerance was not rejected."
+    assert "ref3" in matched_ids, "Reference with missing RT was rejected."
+
+    # Test with query missing RT
+    query_missing_rt = Spectrum(
+        mz=np.array([100.0, 200.0, 300.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 1.0], dtype="float"),
+        metadata={"id": "query2", "precursor_mz": 400.0},
+    )
+
+    results_missing = engine.search(
+        query_spectra=[query_missing_rt],
+        reference_spectra=[ref_nomatch],
+        include_decoys=False,
+    )
+
+    assert len(results_missing) == 1, "Query missing RT rejected a reference."


### PR DESCRIPTION
Added `rt_tolerance` configuration support to filter references whose retention time falls outside the range of `query_rt ± rt_tolerance`. Safely bypassed checking when RT metadata is missing from either query or reference spectra. Added corresponding test coverage to verify correct rejection and safe fallback.

---
*PR created automatically by Jules for task [18028659478055307491](https://jules.google.com/task/18028659478055307491) started by @janusson*